### PR TITLE
fix: 修复分组选择页晃动并优化目录分组

### DIFF
--- a/app/src/main/java/com/mozhi/reader/feature/bookshelf/ShelfOrganizationComponents.kt
+++ b/app/src/main/java/com/mozhi/reader/feature/bookshelf/ShelfOrganizationComponents.kt
@@ -358,6 +358,7 @@ internal fun ShelfGroupPickerSheet(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
+        sheetGesturesEnabled = false,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ) {
         Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp).navigationBarsPadding()) {


### PR DESCRIPTION
## 更新点

- 修复书架多选书籍修改分组时，大幅下滑导致 BottomSheet 上下晃动的问题；仅禁用该选择页的拖拽手势，不改变页面高度、间距或显示样式。
- 文件夹导入仅按实际扫描并选中的书籍建立分组，空文件夹不再被索引为分组。

## 验证

- 实机验证分组选择页大幅下滑后不再晃动。
- 实机验证导入书籍时不再生成空文件夹分组。
- `:app:assembleRelease` 构建通过。